### PR TITLE
fix(types): align RangeQueryParam to OpenAPI spec (string instead of number)

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,22 +172,26 @@ By using the cursor, you can pinpoint the exact position in the paginated datase
 
 Additionally, Narvi's API provides the `RangeQueryParam` interface, which you can use to filter resources based on specific criteria such as date range or amount range. These filters can be applied when making requests to certain endpoints that support filtering.
 
-**Timestamp values must be Unix timestamps in milliseconds** (13-digit numbers).
+**Timestamp values must be Unix timestamps in milliseconds passed as strings**
+(13-digit numbers stringified, e.g. `'1669815899170'`). This matches the
+[OpenAPI specification](https://api.narvi.com/docs/business-banking/api) and the
+[narvi-python SDK](https://github.com/narvicom/narvi-python), and is required for
+the request signature to validate server-side.
 
 Example usage for filtering based on date range:
 
 ```typescript
 const response = await narvi.someFilteredEndpoint.list({
-  added__gte: startTime,  // Unix timestamp in milliseconds
-  added__lte: endTime,    // Unix timestamp in milliseconds
+  added__gte: startTime,  // Unix timestamp in milliseconds, as string
+  added__lte: endTime,    // Unix timestamp in milliseconds, as string
 });
 
 // Example - return all CREDIT transactions for a specific account between a date range
 const response = await narvi.transactions.list({
   account_pid: 'KFGKJ5L27ASGTZAO',
   kind: 'CREDIT',
-  added__gte: 1669815899170,
-  added__lte: 1669815899360,
+  added__gte: '1669815899170',
+  added__lte: '1669815899360',
 });
 ```
 

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -143,24 +143,26 @@ declare module 'narvi' {
 
     interface RangeQueryParam {
       /**
-       * Minimum date value to filter by (inclusive)
+       * Minimum date value to filter by (inclusive).
+       * Unix timestamp in milliseconds, passed as a string (e.g. `'1669815899170'`).
        */
-      added__gte?: number
+      added__gte?: string
 
       /**
-       * Maximum value to filter by (inclusive)
+       * Maximum date value to filter by (inclusive).
+       * Unix timestamp in milliseconds, passed as a string (e.g. `'1669815899360'`).
        */
-      added__lte?: number
+      added__lte?: string
 
       /**
-       * Minimum amount value to filter by (inclusive)
+       * Minimum amount value to filter by (inclusive), passed as a string.
        */
-      amount__gte?: number
+      amount__gte?: string
 
       /**
-       * Maximum amount value to filter by (inclusive)
+       * Maximum amount value to filter by (inclusive), passed as a string.
        */
-      amount__lte?: number
+      amount__lte?: string
     }
 
     interface PaginationParams {


### PR DESCRIPTION
## Summary

Aligns the `RangeQueryParam` interface in `types/shared.d.ts` with the official OpenAPI specification and the narvi-python SDK by declaring `added__gte`, `added__lte`, `amount__gte`, `amount__lte` as `string` instead of `number`. Also updates the README example to use string literals.

Closes #3 — see the issue for full diagnosis and reproduction.

## Why

The current types declare `number`, but at runtime the Narvi API requires these values to be **strings**. Two independent sources confirm this:

1. **Official OpenAPI spec** (`/rest/v1.0/transactions/list`):
   ```yaml
   - name: added__gte
     in: query
     description: Transaction added timestamp filter (in milliseconds).
     schema:
       type: string
   ```

2. **narvi-python SDK** ([`narvi/client.py`](https://github.com/narvicom/narvi-python/blob/main/narvi/client.py)):
   ```python
   query_params["added__lte"] = str(added__lte)
   query_params["added__gte"] = str(added__gte)
   ```

The root cause is in the request signing path: `getNarviRequestSignature` runs `jsonStringify(queryParams)` over the original JS values. When a `number` is passed, the canonical JSON contains `{"added__gte":1669815899170}` (unquoted). The server, however, reconstructs `queryParams` from the URL querystring — where all values are strings — and computes `{"added__gte":"1669815899170"}` (quoted). The two canonical strings hash differently, the signature fails to validate, and the request silently returns empty results.

## What changed

- `types/shared.d.ts` — four fields of `RangeQueryParam` changed from `number` to `string`, with updated JSDoc clarifying the expected format (Unix ms as string).
- `README.md` — the filtering example now uses string literals (`'1669815899170'`) and references both the OpenAPI spec and the Python SDK as the source of truth.

## Impact on existing users

- Users currently passing numbers (per the previous types) are likely already broken at runtime (silent empty results). This change surfaces the bug at compile time with a clear path forward (`String(ts)` or a string literal).
- Users already on the documented `String(...)` / `as any` workaround can drop the `as any` cast.
- No runtime logic changes — signing path, request building, and HTTP layer are untouched.

## Test plan

- [x] `RangeQueryParam` type-checks against the new declaration
- [x] README example compiles and matches the updated types
- [x] Diff inspected for any other call site referencing these fields (none in this repo)

## Context

Follow-up to #2 (docs-only). After that PR was merged I noticed our production code at Boutique del Fitness uses `String(...)` with `as any` because passing numbers literally never returns data — which led to investigating and finding that the root cause is the type declaration itself diverging from the OpenAPI spec.